### PR TITLE
fix inertia scroll for AOSP based ROM

### DIFF
--- a/drivers/input/touchscreen/nt36672c/nt36xxx.c
+++ b/drivers/input/touchscreen/nt36672c/nt36xxx.c
@@ -88,7 +88,9 @@ extern void dsi_panel_doubleclick_enable(bool on);
 static int32_t nvt_check_palm(uint8_t input_id, uint8_t *data);
 extern void touch_irq_boost(void);
 extern void lpm_disable_for_dev(bool on, char event_dev);
+#if XIAOMI_ROI
 extern void xiaomi_touch_send_btn_tap_key(int status);
+#endif
 uint32_t ENG_RST_ADDR  = 0x7FFF80;
 uint32_t SWRST_N8_ADDR = 0; /* read from dtsi */
 uint32_t SPI_RD_FAST_ADDR = 0;	/* read from dtsi */

--- a/drivers/input/touchscreen/xiaomi/xiaomi_touch.c
+++ b/drivers/input/touchscreen/xiaomi/xiaomi_touch.c
@@ -513,6 +513,7 @@ static int xiaomi_touch_parse_dt(struct device *dev, struct xiaomi_touch_pdata *
 	return 0;
 }
 
+#if XIAOMI_ROI
 void xiaomi_touch_send_btn_tap_key(int status)
 {
 	if (xiaomi_touch_dev.key_input_dev) {
@@ -526,6 +527,7 @@ void xiaomi_touch_send_btn_tap_key(int status)
 	}
 }
 EXPORT_SYMBOL(xiaomi_touch_send_btn_tap_key);
+#endif
 
 static int xiaomi_touch_probe(struct platform_device *pdev)
 {

--- a/drivers/input/touchscreen/xiaomi/xiaomi_touch.h
+++ b/drivers/input/touchscreen/xiaomi/xiaomi_touch.h
@@ -67,7 +67,7 @@ do { \
 } while (0)
 
 
-#define XIAOMI_ROI	1
+#define XIAOMI_ROI	0
 
 #if XIAOMI_ROI
 #define DIFF_SENSE_NODE 7


### PR DESCRIPTION
Disable the IRQ boost for touch as this only causes garbage data to be spammed & disable accidental touches as this doesn't work properly on AOSP & takes false positives causing alot of issues like lack of inertia in chrome scrolling & gestures not working correctly on launcher.

Related commit: https://github.com/LineageOS/android_kernel_xiaomi_sm8250/commit/5b814af0ec5547e55c8fdd8104efef7ea42e73ba